### PR TITLE
[systemd] Add workaround for OBS dependency problem for building systemd. JB#55010

### DIFF
--- a/rpm/systemd-mini.spec
+++ b/rpm/systemd-mini.spec
@@ -88,6 +88,8 @@ BuildRequires:  pkgconfig(libcryptsetup) >= 1.6.0
 BuildRequires:  pkgconfig(liblzma)
 BuildRequires:  pkgconfig(libgcrypt)
 BuildRequires:  pkgconfig(libselinux)
+# this is needed for OBS workaround
+BuildRequires:  pkgconfig(libsystemd)
 %endif
 BuildRequires:  pkgconfig(libacl)
 BuildRequires:  pkgconfig(libcap)

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -87,6 +87,8 @@ BuildRequires:  pkgconfig(libcryptsetup) >= 1.6.0
 BuildRequires:  pkgconfig(liblzma)
 BuildRequires:  pkgconfig(libgcrypt)
 BuildRequires:  pkgconfig(libselinux)
+# this is needed for OBS workaround
+BuildRequires:  pkgconfig(libsystemd)
 %endif
 BuildRequires:  pkgconfig(libacl)
 BuildRequires:  pkgconfig(libcap)


### PR DESCRIPTION
In theory this should not be needed. OBS should be able to pull in the correct
systemd-libs-mini, but possibly our prjconf prevents that from happening.
We will investigate a way to drop this dependency later.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
Signed-off-by: Niels Breet <niels.breet@jolla.com>