### PR TITLE
[systemctl-user] Fix systemctl-user edit command. Fixes JB#56246

### DIFF
--- a/rpm/systemctl-user
+++ b/rpm/systemctl-user
@@ -29,5 +29,7 @@
 
 USER_ID=$(id -u $(loginctl list-sessions | grep seat0 | tr -s " " | cut -d " " -f 4))
 export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$USER_ID/dbus/user_bus_socket"
+export USER=$(getent passwd $USER_ID | cut -d: -f1)
+export HOME=$(getent passwd $USER_ID | cut -d: -f6)
 
 systemctl --user $@

--- a/rpm/systemctl-user
+++ b/rpm/systemctl-user
@@ -32,4 +32,4 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$USER_ID/dbus/user_bus_sock
 export USER=$(getent passwd $USER_ID | cut -d: -f1)
 export HOME=$(getent passwd $USER_ID | cut -d: -f6)
 
-systemctl --user $@
+exec systemctl --user $@


### PR DESCRIPTION
Previously running systemctl-user edit as root opened the file in root's home directory. Setting HOME to seat0 user opens the expected file. Set also USER environment variable for good measure.

Make systemctl replace shell. If systemctl-user is used as part of systemd unit it might not be properly terminated sometimes. This makes systemctl to replace shell which allows systemd to properly manage process lifetimes.
