### PR TITLE
Fix most tests

### DIFF
--- a/rpm/0003-Move-large-array-out-of-stack.patch
+++ b/rpm/0003-Move-large-array-out-of-stack.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20Lepp=C3=A4nen?= <tomi.leppanen@jolla.com>
+Date: Wed, 9 Mar 2022 11:15:36 +0200
+Subject: [PATCH] Move large array out of stack
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This avoids segfault.
+
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
+---
+ src/journal/test-compress.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/journal/test-compress.c b/src/journal/test-compress.c
+index ea1ffcc4af..f6e7e3457f 100644
+--- a/src/journal/test-compress.c
++++ b/src/journal/test-compress.c
+@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
+ 
+         char data[512] = "random\0";
+ 
+-        char huge[4096*1024];
++        static char huge[4096*1024];
+         memset(huge, 'x', sizeof(huge));
+         memcpy(huge, "HUGE=", 5);
+         char_array_0(huge);
+-- 
+2.35.1
+

--- a/rpm/0004-Fix-busybox-compatibility-for-test-execute.patch
+++ b/rpm/0004-Fix-busybox-compatibility-for-test-execute.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20Lepp=C3=A4nen?= <tomi.leppanen@jolla.com>
+Date: Wed, 9 Mar 2022 14:14:53 +0200
+Subject: [PATCH] Fix busybox compatibility for test-execute
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
+---
+ test/test-execute/exec-specifier.service  | 2 +-
+ test/test-execute/exec-specifier@.service | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/test-execute/exec-specifier.service b/test/test-execute/exec-specifier.service
+index 37852390ac..2c4d882da9 100644
+--- a/test/test-execute/exec-specifier.service
++++ b/test/test-execute/exec-specifier.service
+@@ -14,7 +14,7 @@ ExecStart=/usr/bin/test %t = /run
+ ExecStart=/usr/bin/test %S = /var/lib
+ ExecStart=/usr/bin/test %C = /var/cache
+ ExecStart=/usr/bin/test %L = /var/log
+-ExecStart=/bin/sh -c 'test %u = $$(id -un 0)'
++ExecStart=/bin/sh -c 'test %u = $$(getent passwd 0 | cut -d: -f 1)'
+ ExecStart=/usr/bin/test %U = 0
+ ExecStart=/bin/sh -c 'test %h = $$(getent passwd 0 | cut -d: -f 6)
+ ExecStart=/bin/sh -c 'test %s = $$(getent passwd 0 | cut -d: -f 7)
+diff --git a/test/test-execute/exec-specifier@.service b/test/test-execute/exec-specifier@.service
+index 0015dffca6..1f45d6807a 100644
+--- a/test/test-execute/exec-specifier@.service
++++ b/test/test-execute/exec-specifier@.service
+@@ -14,7 +14,7 @@ ExecStart=/usr/bin/test %t = /run
+ ExecStart=/usr/bin/test %S = /var/lib
+ ExecStart=/usr/bin/test %C = /var/cache
+ ExecStart=/usr/bin/test %L = /var/log
+-ExecStart=/bin/sh -c 'test %u = $$(id -un 0)'
++ExecStart=/bin/sh -c 'test %u = $$(getent passwd 0 | cut -d: -f 1)'
+ ExecStart=/usr/bin/test %U = 0
+ ExecStart=/bin/sh -c 'test %h = $$(getent passwd 0 | cut -d: -f 6)
+ ExecStart=/bin/sh -c 'test %s = $$(getent passwd 0 | cut -d: -f 7)
+-- 
+2.35.1
+

--- a/rpm/0005-Skip-tests-in-test-execute-that-don-t-work.patch
+++ b/rpm/0005-Skip-tests-in-test-execute-that-don-t-work.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20Lepp=C3=A4nen?= <tomi.leppanen@jolla.com>
+Date: Wed, 9 Mar 2022 16:55:21 +0200
+Subject: [PATCH] Skip tests in test-execute that don't work
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Those readonlypaths tests do not currently work on linux <= 4.17. They
+should work after systemd is updated to 240.
+
+That dynamicuser-statedir test requires find with -writable argument
+support which is not available in busybox find.
+
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
+---
+ src/test/test-execute.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/test/test-execute.c b/src/test/test-execute.c
+index 645e0b3d47..3def74d916 100644
+--- a/src/test/test-execute.c
++++ b/src/test/test-execute.c
+@@ -291,9 +291,12 @@ static void test_exec_readonlypaths(Manager *m) {
+                 return;
+         }
+ 
++// This test does not work with linux <= 4.17 and systemd < 240 combination
++#if 0
+         test(m, "exec-readonlypaths.service", 0, CLD_EXITED);
+-        test(m, "exec-readonlypaths-mount-propagation.service", 0, CLD_EXITED);
+         test(m, "exec-readonlypaths-with-bindpaths.service", 0, CLD_EXITED);
++#endif
++        test(m, "exec-readonlypaths-mount-propagation.service", 0, CLD_EXITED);
+ }
+ 
+ static void test_exec_readwritepaths(Manager *m) {
+@@ -441,7 +444,10 @@ static void test_exec_dynamicuser(Manager *m) {
+         test(m, "exec-dynamicuser-fixeduser.service", 0, CLD_EXITED);
+         test(m, "exec-dynamicuser-fixeduser-one-supplementarygroup.service", 0, CLD_EXITED);
+         test(m, "exec-dynamicuser-supplementarygroups.service", 0, CLD_EXITED);
++// This test does not work with busybox find that's missing -writeable
++#if 0
+         test(m, "exec-dynamicuser-statedir.service", 0, CLD_EXITED);
++#endif
+ 
+         test(m, "exec-dynamicuser-statedir-migrate-step1.service", 0, CLD_EXITED);
+         test(m, "exec-dynamicuser-statedir-migrate-step2.service", 0, CLD_EXITED);
+-- 
+2.35.1
+

--- a/rpm/systemd-239-test-execute-allow-sit0-to-exist-in-private-network-.patch
+++ b/rpm/systemd-239-test-execute-allow-sit0-to-exist-in-private-network-.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Thu, 22 Mar 2018 08:50:10 +0100
+Subject: [PATCH] test-execute: allow sit0@ to exist in private network
+ namespace
+
+It's always visible:
+
+$ sudo modprobe sit
+$ sudo unshare -n ip l
+1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
+    ...
+2: sit0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default qlen 1000
+    ...
+---
+ test/test-execute/exec-privatenetwork-yes.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/test-execute/exec-privatenetwork-yes.service b/test/test-execute/exec-privatenetwork-yes.service
+index 5077f7eed2..a38d24912f 100644
+--- a/test/test-execute/exec-privatenetwork-yes.service
++++ b/test/test-execute/exec-privatenetwork-yes.service
+@@ -2,6 +2,6 @@
+ Description=Test for PrivateNetwork
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c '! ip link | grep ": " | grep -v ": lo:"'
++ExecStart=/bin/sh -x -c '! ip link | grep ": " | grep -Ev ": (lo|sit0@.*):"'
+ Type=oneshot
+ PrivateNetwork=yes
+-- 
+2.35.1
+

--- a/rpm/systemd-239-test-execute-simplify-checks-if-grep-output-is-empty.patch
+++ b/rpm/systemd-239-test-execute-simplify-checks-if-grep-output-is-empty.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Thu, 22 Mar 2018 08:42:02 +0100
+Subject: [PATCH] test-execute: simplify checks if grep output is empty
+
+grep already indicates if it matched anything by return value.
+Additional advantage is then that if the test fails, the unexpected
+matching lines are visible in the log output.
+---
+ test/test-execute/exec-capabilityboundingset-invert.service | 2 +-
+ test/test-execute/exec-privatenetwork-yes.service           | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/test-execute/exec-capabilityboundingset-invert.service b/test/test-execute/exec-capabilityboundingset-invert.service
+index fd5d248702..1abe390601 100644
+--- a/test/test-execute/exec-capabilityboundingset-invert.service
++++ b/test/test-execute/exec-capabilityboundingset-invert.service
+@@ -2,6 +2,6 @@
+ Description=Test for CapabilityBoundingSet
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'c=$$(capsh --print | grep "^Bounding set .*cap_chown"); test -z "$$c"'
++ExecStart=/bin/sh -x -c '! capsh --print | grep "^Bounding set .*cap_chown"'
+ Type=oneshot
+ CapabilityBoundingSet=~CAP_CHOWN
+diff --git a/test/test-execute/exec-privatenetwork-yes.service b/test/test-execute/exec-privatenetwork-yes.service
+index 3df543ec93..5077f7eed2 100644
+--- a/test/test-execute/exec-privatenetwork-yes.service
++++ b/test/test-execute/exec-privatenetwork-yes.service
+@@ -2,6 +2,6 @@
+ Description=Test for PrivateNetwork
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'i=$$(ip link | grep ": " | grep -v ": lo:"); test -z "$$i"'
++ExecStart=/bin/sh -x -c '! ip link | grep ": " | grep -v ": lo:"'
+ Type=oneshot
+ PrivateNetwork=yes
+-- 
+2.35.1
+

--- a/rpm/systemd-240-test-execute-filter-out-ip6tnl0-and-ip6gre0-interfac.patch
+++ b/rpm/systemd-240-test-execute-filter-out-ip6tnl0-and-ip6gre0-interfac.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
+Date: Tue, 9 Oct 2018 14:08:09 +0200
+Subject: [PATCH] test-execute: filter out ip6tnl0@ and ip6gre0@ interfaces
+
+Those interfaces are created automatically when ip6_tunnel and ip6_gre loaded.
+They break the test with exec-privatenetwork-yes.service.
+
+C.f. 6b08180ca6f1ceb913f6a69ffcaf96e9818fbdf5.
+---
+ test/test-execute/exec-privatenetwork-yes.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/test-execute/exec-privatenetwork-yes.service b/test/test-execute/exec-privatenetwork-yes.service
+index a38d24912f..ded8d55126 100644
+--- a/test/test-execute/exec-privatenetwork-yes.service
++++ b/test/test-execute/exec-privatenetwork-yes.service
+@@ -2,6 +2,6 @@
+ Description=Test for PrivateNetwork
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c '! ip link | grep ": " | grep -Ev ": (lo|sit0@.*):"'
++ExecStart=/bin/sh -x -c '! ip link | grep ": " | grep -Ev ": (lo|(sit0|ip6tnl0|ip6gre0)@.*):"'
+ Type=oneshot
+ PrivateNetwork=yes
+-- 
+2.35.1
+

--- a/rpm/systemd-240-test-fix-tests-for-supplementary-groups.patch
+++ b/rpm/systemd-240-test-fix-tests-for-supplementary-groups.patch
@@ -1,0 +1,152 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Sat, 29 Sep 2018 21:05:52 +0900
+Subject: [PATCH] test: fix tests for supplementary groups
+
+Fixes #9881.
+---
+ ...xec-dynamicuser-fixeduser-one-supplementarygroup.service | 3 ++-
+ test/test-execute/exec-dynamicuser-fixeduser.service        | 3 ++-
+ .../exec-dynamicuser-supplementarygroups.service            | 4 +++-
+ ...mentarygroups-multiple-groups-default-group-user.service | 6 +++++-
+ ...exec-supplementarygroups-multiple-groups-withgid.service | 5 ++++-
+ ...exec-supplementarygroups-multiple-groups-withuid.service | 4 +++-
+ .../exec-supplementarygroups-single-group-user.service      | 3 ++-
+ .../exec-supplementarygroups-single-group.service           | 3 ++-
+ test/test-execute/exec-supplementarygroups.service          | 3 ++-
+ 9 files changed, 25 insertions(+), 9 deletions(-)
+
+diff --git a/test/test-execute/exec-dynamicuser-fixeduser-one-supplementarygroup.service b/test/test-execute/exec-dynamicuser-fixeduser-one-supplementarygroup.service
+index de1a6e7303..bd7881d286 100644
+--- a/test/test-execute/exec-dynamicuser-fixeduser-one-supplementarygroup.service
++++ b/test/test-execute/exec-dynamicuser-fixeduser-one-supplementarygroup.service
+@@ -2,7 +2,8 @@
+ Description=Test DynamicUser with User= and SupplementaryGroups=
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "1" && test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
++ExecStart=/bin/sh -x -c 'HAVE=0; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
+ Type=oneshot
+ User=1
+ DynamicUser=yes
+diff --git a/test/test-execute/exec-dynamicuser-fixeduser.service b/test/test-execute/exec-dynamicuser-fixeduser.service
+index 1d84af02ed..f28078f242 100644
+--- a/test/test-execute/exec-dynamicuser-fixeduser.service
++++ b/test/test-execute/exec-dynamicuser-fixeduser.service
+@@ -2,7 +2,8 @@
+ Description=Test DynamicUser with User=
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "1" && test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
++ExecStart=/bin/sh -x -c 'HAVE=0; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
+ Type=oneshot
+ User=1
+ DynamicUser=yes
+diff --git a/test/test-execute/exec-dynamicuser-supplementarygroups.service b/test/test-execute/exec-dynamicuser-supplementarygroups.service
+index a47b7fab78..9ee6154f95 100644
+--- a/test/test-execute/exec-dynamicuser-supplementarygroups.service
++++ b/test/test-execute/exec-dynamicuser-supplementarygroups.service
+@@ -2,7 +2,9 @@
+ Description=Test DynamicUser with SupplementaryGroups=
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G | cut -d " " --complement -f 1)" = "1 2 3"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "2" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "3" && HAVE=1; done; test "$$HAVE" -eq 1'
+ Type=oneshot
+ DynamicUser=yes
+ SupplementaryGroups=1 2 3
+diff --git a/test/test-execute/exec-supplementarygroups-multiple-groups-default-group-user.service b/test/test-execute/exec-supplementarygroups-multiple-groups-default-group-user.service
+index a49c9d26a1..1c565b4122 100644
+--- a/test/test-execute/exec-supplementarygroups-multiple-groups-default-group-user.service
++++ b/test/test-execute/exec-supplementarygroups-multiple-groups-default-group-user.service
+@@ -2,6 +2,10 @@
+ Description=Test for Supplementary Group with multiple groups without Group and User
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "0 1 2 3" && test "$$(id -g)" = "0" && test "$$(id -u)" = "0"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "0" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "2" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "3" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'test "$$(id -g)" = "0" && test "$$(id -u)" = "0"'
+ Type=oneshot
+ SupplementaryGroups=1 2 3
+diff --git a/test/test-execute/exec-supplementarygroups-multiple-groups-withgid.service b/test/test-execute/exec-supplementarygroups-multiple-groups-withgid.service
+index 5c62c1d639..45bcf79222 100644
+--- a/test/test-execute/exec-supplementarygroups-multiple-groups-withgid.service
++++ b/test/test-execute/exec-supplementarygroups-multiple-groups-withgid.service
+@@ -2,7 +2,10 @@
+ Description=Test for Supplementary Group with multiple groups and Group=1
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "1 2 3" && test "$$(id -g)" = "1" && test "$$(id -u)" = "0"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "2" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "3" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'test "$$(id -g)" = "1" && test "$$(id -u)" = "0"'
+ Type=oneshot
+ Group=1
+ SupplementaryGroups=1 2 3
+diff --git a/test/test-execute/exec-supplementarygroups-multiple-groups-withuid.service b/test/test-execute/exec-supplementarygroups-multiple-groups-withuid.service
+index 00523e383b..62e56a2c23 100644
+--- a/test/test-execute/exec-supplementarygroups-multiple-groups-withuid.service
++++ b/test/test-execute/exec-supplementarygroups-multiple-groups-withuid.service
+@@ -2,7 +2,9 @@
+ Description=Test for Supplementary Group with multiple groups and Uid=1
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "1 2 3" && test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "2" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "3" && HAVE=1; done; test "$$HAVE" -eq 1'
+ Type=oneshot
+ User=1
+ SupplementaryGroups=1 2 3
+diff --git a/test/test-execute/exec-supplementarygroups-single-group-user.service b/test/test-execute/exec-supplementarygroups-single-group-user.service
+index ed6276d303..97f9f9c786 100644
+--- a/test/test-execute/exec-supplementarygroups-single-group-user.service
++++ b/test/test-execute/exec-supplementarygroups-single-group-user.service
+@@ -2,7 +2,8 @@
+ Description=Test for Supplementary Group with only one group and uid 1
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "1" && test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'test "$$(id -g)" = "1" && test "$$(id -u)" = "1"'
+ Type=oneshot
+ User=1
+ Group=1
+diff --git a/test/test-execute/exec-supplementarygroups-single-group.service b/test/test-execute/exec-supplementarygroups-single-group.service
+index ee502b3d37..f9b721696b 100644
+--- a/test/test-execute/exec-supplementarygroups-single-group.service
++++ b/test/test-execute/exec-supplementarygroups-single-group.service
+@@ -2,7 +2,8 @@
+ Description=Test for Supplementary Group with only one group
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "1" && test "$$(id -g)" = "1" && test "$$(id -u)" = "0"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'test "$$(id -g)" = "1" && test "$$(id -u)" = "0"'
+ Type=oneshot
+ Group=1
+ SupplementaryGroups=1
+diff --git a/test/test-execute/exec-supplementarygroups.service b/test/test-execute/exec-supplementarygroups.service
+index 43a9a981f2..4dee6af748 100644
+--- a/test/test-execute/exec-supplementarygroups.service
++++ b/test/test-execute/exec-supplementarygroups.service
+@@ -2,6 +2,7 @@
+ Description=Test for Supplementary Group
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c 'test "$$(id -G)" = "0 1"'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "0" && HAVE=1; done; test "$$HAVE" -eq 1'
++ExecStart=/bin/sh -x -c 'HAVE=; for g in $$(id -G); do test "$$g" = "1" && HAVE=1; done; test "$$HAVE" -eq 1'
+ Type=oneshot
+ SupplementaryGroups=1
+-- 
+2.35.1
+

--- a/rpm/systemd-241-test-network-ignore-tunnel-devices-automatically-add.patch
+++ b/rpm/systemd-241-test-network-ignore-tunnel-devices-automatically-add.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Wed, 6 Feb 2019 12:02:15 +0100
+Subject: [PATCH] test-network: ignore tunnel devices automatically added by
+ kernel
+
+Fixes #10934.
+---
+ test/test-execute/exec-privatenetwork-yes.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/test-execute/exec-privatenetwork-yes.service b/test/test-execute/exec-privatenetwork-yes.service
+index ded8d55126..8f5cbadf04 100644
+--- a/test/test-execute/exec-privatenetwork-yes.service
++++ b/test/test-execute/exec-privatenetwork-yes.service
+@@ -2,6 +2,6 @@
+ Description=Test for PrivateNetwork
+ 
+ [Service]
+-ExecStart=/bin/sh -x -c '! ip link | grep ": " | grep -Ev ": (lo|(sit0|ip6tnl0|ip6gre0)@.*):"'
++ExecStart=/bin/sh -x -c '! ip link | grep -E "^[0-9]+: " | grep -Ev ": (lo|(erspan|gre|gretap|ip_vti|ip6_vti|ip6gre|ip6tnl|sit|tunl)0@.*):"'
+ Type=oneshot
+ PrivateNetwork=yes
+-- 
+2.35.1
+

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -74,6 +74,13 @@ Patch63:        systemd-249-journald-Retry-if-posix_fallocate-returned-1-EINTR.p
 Patch64:        systemd-meson-do-not-fail-if-rsync-is-not-installed-with-mes.patch
 # Unit test fixes JB#52768
 Patch70:        0003-Move-large-array-out-of-stack.patch
+Patch71:        systemd-239-test-execute-simplify-checks-if-grep-output-is-empty.patch
+Patch72:        systemd-239-test-execute-allow-sit0-to-exist-in-private-network-.patch
+Patch73:        systemd-240-test-execute-filter-out-ip6tnl0-and-ip6gre0-interfac.patch
+Patch74:        systemd-241-test-network-ignore-tunnel-devices-automatically-add.patch
+Patch75:        systemd-240-test-fix-tests-for-supplementary-groups.patch
+Patch76:        0004-Fix-busybox-compatibility-for-test-execute.patch
+Patch77:        0005-Skip-tests-in-test-execute-that-don-t-work.patch
 # This patch serves two purposes: it adds needed "#include <sys/sysmacros.h>"
 # and initializes variables with automatic cleanup functions to silence
 # compiler warnings.
@@ -201,6 +208,7 @@ Summary:   Systemd tests
 Requires:  %{name} = %{version}-%{release}
 Requires:  blts-tools
 Requires:  acl
+Requires:  perl
 
 %description tests
 This package includes tests for systemd.

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -72,6 +72,8 @@ Patch61:        systemd-245-polkit-async-CVE-2020-1712.diff
 Patch62:        systemd-pam_limits-fix.patch
 Patch63:        systemd-249-journald-Retry-if-posix_fallocate-returned-1-EINTR.patch
 Patch64:        systemd-meson-do-not-fail-if-rsync-is-not-installed-with-mes.patch
+# Unit test fixes JB#52768
+Patch70:        0003-Move-large-array-out-of-stack.patch
 # This patch serves two purposes: it adds needed "#include <sys/sysmacros.h>"
 # and initializes variables with automatic cleanup functions to silence
 # compiler warnings.

--- a/rpm/tests.xml
+++ b/rpm/tests.xml
@@ -38,24 +38,25 @@
       <case name="test-audit-type">
         <step> /usr/lib/systemd/tests/test-audit-type </step>
       </case>
+<!-- Has a dummy argument -->
       <case name="test-barrier">
-        <step> /usr/lib/systemd/tests/test-barrier </step>
+        <step> /usr/lib/systemd/tests/test-barrier run </step>
       </case>
       <case name="test-bitmap">
         <step> /usr/lib/systemd/tests/test-bitmap </step>
       </case>
+<!-- Bpf support from kernel, so it depends on device whether this will pass. Needs root. -->
       <case name="test-bpf">
-        <step> /usr/lib/systemd/tests/test-bpf </step>
+        <step> /usr/sbin/run-blts-root /usr/lib/systemd/tests/test-bpf </step>
       </case>
-<!--
-      Looks like this test needs to be run with root permissions.
-      Could be fixed if needed.
+<!-- Needs block device with btrfs to work.
       <case name="test-btrfs">
         <step> /usr/lib/systemd/tests/manual/test-btrfs </step>
       </case>
 -->
+<!-- This is also a benchmark so displaying some data would be appropriate. -->
       <case name="test-bus-benchmark">
-        <step> /usr/lib/systemd/tests/manual/test-bus-benchmark </step>
+        <step> /usr/lib/systemd/tests/manual/test-bus-benchmark chart </step>
       </case>
       <case name="test-bus-chat">
         <step> /usr/lib/systemd/tests/test-bus-chat </step>
@@ -105,10 +106,9 @@
       <case name="test-calendarspec">
         <step> /usr/lib/systemd/tests/test-calendarspec </step>
       </case>
-      <!-- Will fail on kernels <= v4.3 because of lack of ambient
-           capabilities support -->
+<!-- Will fail on kernels <= v4.3 because of lack of ambient capabilities support. Requires root. -->
       <case name="test-capability">
-        <step> /usr/lib/systemd/tests/test-capability </step>
+        <step> /usr/sbin/run-blts-root /usr/lib/systemd/tests/test-capability </step>
       </case>
       <case name="test-cap-list">
         <step> /usr/lib/systemd/tests/test-cap-list </step>
@@ -119,6 +119,7 @@
         <step> /usr/lib/systemd/tests/test-catalog </step>
       </case>
 -->
+<!-- Not working, unclear why -->
       <case name="test-cgroup">
         <step> /usr/lib/systemd/tests/manual/test-cgroup </step>
       </case>
@@ -213,6 +214,7 @@
       <case name="test-fdset">
         <step> /usr/lib/systemd/tests/test-fdset </step>
       </case>
+<!-- Not working, unclear why -->
       <case name="test-fd-util">
         <step> /usr/lib/systemd/tests/test-fd-util </step>
       </case>
@@ -231,10 +233,9 @@
       <case name="test-glob-util">
         <step> /usr/lib/systemd/tests/test-glob-util </step>
       </case>
-      <!-- Could fail if the kernel is built without CONFIG_CRYPTO_USER*
-           options. -->
+<!-- Fails if the kernel is built without CONFIG_CRYPTO_USER* options, expecting skipped status. -->
       <case name="test-hash">
-        <step> /usr/lib/systemd/tests/test-hash </step>
+        <step expected_result="77"> /usr/lib/systemd/tests/test-hash </step>
       </case>
       <case name="test-hashmap">
         <step> /usr/lib/systemd/tests/test-hashmap </step>
@@ -501,7 +502,8 @@
       <case name="test-tmpfiles">
         <step> /usr/lib/systemd/tests/test-tmpfiles </step>
       </case>
-<!--  The test doesn't work.
+<!-- This would need an udev action and a device path to work.
+     It could be made to work with more effort probably.
       <case name="test-udev">
         <step> /usr/sbin/run-blts-root /usr/lib/systemd/tests/manual/test-udev </step>
       </case>

--- a/rpm/tests.xml
+++ b/rpm/tests.xml
@@ -197,6 +197,10 @@
       <case name="test-event">
         <step> /usr/lib/systemd/tests/test-event </step>
       </case>
+<!-- Note: This has patches to skip parts
+     Some of those require either linux > 4.17 or systemd >= 240.
+     Others use features not available on busybox.
+-->
       <case name="test-execute">
         <step> /usr/sbin/run-blts-root /usr/lib/systemd/tests/test-execute </step>
       </case>


### PR DESCRIPTION
Fixes all but two failing cases, which I added comments about to tests.xml but I'm not sure if we should comment them out or try harder to fix them. Anyway this already improves a lot.

Patch test-compress to avoid segfault. Too large stack, thus moving a large array out of stack.

Add upstream patches to test-execute, do some fixes for busybox compatibility and skip some tests that don't have a chance to work.

Adjust tests.xml. I changed some tests to expect skipped status (77) because they simply can not work on Sailfish at the moment.