### PR TITLE
[systemd] Replace intltool dependency with gettext. JB#61290

### DIFF
--- a/rpm/systemd-mini.spec
+++ b/rpm/systemd-mini.spec
@@ -111,7 +111,7 @@ BuildRequires:  pkgconfig(libcrypt)
 BuildRequires:  cmake
 BuildRequires:  fdupes
 BuildRequires:  gperf
-BuildRequires:  intltool >= 0.40.0
+BuildRequires:  gettext
 BuildRequires:  libtool
 BuildRequires:  libxslt
 BuildRequires:  meson

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -110,7 +110,7 @@ BuildRequires:  pkgconfig(libcrypt)
 BuildRequires:  cmake
 BuildRequires:  fdupes
 BuildRequires:  gperf
-BuildRequires:  intltool >= 0.40.0
+BuildRequires:  gettext
 BuildRequires:  libtool
 BuildRequires:  libxslt
 BuildRequires:  meson


### PR DESCRIPTION
Version 236 switched to use just gettext.