### PR TITLE
Disable resolved DNSSEC by default JB#63704

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Packaging guide
+
+**All changes go to rpm/systemd.spec !**
+
+To update rpm/systemd-mini.spec run
+
+    ./precheckin.sh

--- a/precheckin.sh
+++ b/precheckin.sh
@@ -3,6 +3,7 @@
 # This script is based on libcdio_spec-prepare.sh (thanks to sbrabec@suse.cz)
 # create a -mini spec for systemd for bootstrapping
 
+pushd rpm
 ORIG_SPEC=systemd
 EDIT_WARNING="##### WARNING: please do not edit this auto generated spec file. Use the ${ORIG_SPEC}.spec! #####\n"
 sed "s/^%bcond_with     systemd_bootstrap.*$/${EDIT_WARNING}%bcond_without     systemd_bootstrap/;

--- a/rpm/systemd-mini.spec
+++ b/rpm/systemd-mini.spec
@@ -254,13 +254,15 @@ CONFIGURE_OPTS=(
         -Dlibcryptsetup=true
         -Dgcrypt=true
         -Dselinux=true
+        -Dresolve=true
+        -Dmyhostname=true
 %else
         -Dtests=false
         -Dinstall-tests=false
-%endif
-        # those also will not work during boostrap if enabled
         -Dresolve=false
         -Dmyhostname=false
+%endif
+        # those also will not work during boostrap if enabled
         -Dmachined=false
         # end
         -Dkmod=true
@@ -410,8 +412,10 @@ getent group systemd-journal >/dev/null 2>&1 || groupadd -r -g 190 systemd-journ
 getent group systemd-network >/dev/null 2>&1 || groupadd -r systemd-network 2>&1 || :
 getent passwd systemd-network >/dev/null 2>&1 || useradd -r -l -g systemd-network -d / -s /sbin/nologin -c "systemd Network Management" systemd-network >/dev/null 2>&1 || :
 
-#getent group systemd-resolve >/dev/null 2>&1 || groupadd -r systemd-resolve 2>&1 || :
-#getent passwd systemd-resolve >/dev/null 2>&1 || useradd -r -l -g systemd-resolve -d / -s /sbin/nologin -c "systemd Resolver" systemd-resolve >/dev/null 2>&1 || :
+%if %{without systemd_bootstrap}
+getent group systemd-resolve >/dev/null 2>&1 || groupadd -r systemd-resolve 2>&1 || :
+getent passwd systemd-resolve >/dev/null 2>&1 || useradd -r -l -g systemd-resolve -d / -s /sbin/nologin -c "systemd Resolver" systemd-resolve >/dev/null 2>&1 || :
+%endif
 
 systemctl stop systemd-udevd-control.socket systemd-udevd-kernel.socket systemd-udevd.service >/dev/null 2>&1 || :
 
@@ -551,6 +555,13 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %license LICENSE.GPL2
 %license LICENSE.LGPL2.1
 
+%if %{without systemd_bootstrap}
+%{_bindir}/systemd-resolve
+%{_datadir}/dbus-1/system-services/org.freedesktop.resolve1.service
+%{_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
+%{_datadir}/polkit-1/actions/org.freedesktop.resolve1.policy
+%endif
+
 # Just make sure we don't package these by default
 %exclude %{_prefix}/lib/systemd/system/default.target
 %exclude %{user_unit_dir}/default.target
@@ -569,6 +580,9 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %{_sysconfdir}/udev/udev.conf
 %{system_unit_dir}/default.target
 %{system_unit_dir}/user@.service
+%if %{without systemd_bootstrap}
+%{_sysconfdir}/systemd/resolved.conf
+%endif
 
 %if %{without systemd_bootstrap}
 %files doc
@@ -591,6 +605,10 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %{_libdir}/libudev.so.*
 %{_libdir}/libsystemd.so.*
 %{_libdir}/libnss_systemd.so.*
+%if %{without systemd_bootstrap}
+%{_libdir}/libnss_resolve.so.2
+%{_libdir}/libnss_myhostname.so.2
+%endif
 
 %files devel
 %dir %{_includedir}/systemd

--- a/rpm/systemd-mini.spec
+++ b/rpm/systemd-mini.spec
@@ -22,7 +22,6 @@ Source3:        systemctl-user
 # We need to disable false positive rpmlint's error in systemd.pc.
 # Can be removed after fixing: https://bugs.merproject.org/show_bug.cgi?id=1341
 Source4:        systemd-rpmlintrc
-Source5:        precheckin.sh
 
 %if %{with systemd_bootstrap}
 Source6:        systemd-mini-rpmlintrc

--- a/rpm/systemd-mini.spec
+++ b/rpm/systemd-mini.spec
@@ -255,6 +255,8 @@ CONFIGURE_OPTS=(
         -Dselinux=true
         -Dresolve=true
         -Dmyhostname=true
+        # Disable DNSSEC by default, until systemd update. JB#63704
+        -Ddefault-dnssec=no
 %else
         -Dtests=false
         -Dinstall-tests=false

--- a/rpm/systemd-mini.spec
+++ b/rpm/systemd-mini.spec
@@ -449,7 +449,6 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %postun libs -p /sbin/ldconfig
 
 %files -f %{_name}.lang
-%defattr(-,root,root,-)
 %dir %{_sysconfdir}/systemd
 %dir %{_sysconfdir}/systemd/system
 %exclude %{_sysconfdir}/systemd/system/getty.target.wants/getty@tty1.service
@@ -572,7 +571,6 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %exclude %{pkgdir}/tests
 
 %files config-mer
-%defattr(-,root,root,-)
 %{_sysconfdir}/systemd/journald.conf
 %{_sysconfdir}/systemd/logind.conf
 %{_sysconfdir}/systemd/system.conf
@@ -586,18 +584,15 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 
 %if %{without systemd_bootstrap}
 %files doc
-%defattr(-,root,root,-)
 %{_docdir}/%{_name}-%{version}
 
 %files tests
-%defattr(-,root,root,-)
 %dir /opt/tests/systemd-tests
 /opt/tests/systemd-tests/tests.xml
 %{pkgdir}/tests
 %endif
 
 %files analyze
-%defattr(-,root,root,-)
 %{_bindir}/systemd-analyze
 
 %files libs

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -448,7 +448,6 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %postun libs -p /sbin/ldconfig
 
 %files -f %{_name}.lang
-%defattr(-,root,root,-)
 %dir %{_sysconfdir}/systemd
 %dir %{_sysconfdir}/systemd/system
 %exclude %{_sysconfdir}/systemd/system/getty.target.wants/getty@tty1.service
@@ -571,7 +570,6 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %exclude %{pkgdir}/tests
 
 %files config-mer
-%defattr(-,root,root,-)
 %{_sysconfdir}/systemd/journald.conf
 %{_sysconfdir}/systemd/logind.conf
 %{_sysconfdir}/systemd/system.conf
@@ -585,18 +583,15 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 
 %if %{without systemd_bootstrap}
 %files doc
-%defattr(-,root,root,-)
 %{_docdir}/%{_name}-%{version}
 
 %files tests
-%defattr(-,root,root,-)
 %dir /opt/tests/systemd-tests
 /opt/tests/systemd-tests/tests.xml
 %{pkgdir}/tests
 %endif
 
 %files analyze
-%defattr(-,root,root,-)
 %{_bindir}/systemd-analyze
 
 %files libs

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -21,7 +21,6 @@ Source3:        systemctl-user
 # We need to disable false positive rpmlint's error in systemd.pc.
 # Can be removed after fixing: https://bugs.merproject.org/show_bug.cgi?id=1341
 Source4:        systemd-rpmlintrc
-Source5:        precheckin.sh
 
 %if %{with systemd_bootstrap}
 Source6:        systemd-mini-rpmlintrc

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -411,8 +411,10 @@ getent group systemd-journal >/dev/null 2>&1 || groupadd -r -g 190 systemd-journ
 getent group systemd-network >/dev/null 2>&1 || groupadd -r systemd-network 2>&1 || :
 getent passwd systemd-network >/dev/null 2>&1 || useradd -r -l -g systemd-network -d / -s /sbin/nologin -c "systemd Network Management" systemd-network >/dev/null 2>&1 || :
 
+%if %{without systemd_bootstrap}
 getent group systemd-resolve >/dev/null 2>&1 || groupadd -r systemd-resolve 2>&1 || :
 getent passwd systemd-resolve >/dev/null 2>&1 || useradd -r -l -g systemd-resolve -d / -s /sbin/nologin -c "systemd Resolver" systemd-resolve >/dev/null 2>&1 || :
+%endif
 
 systemctl stop systemd-udevd-control.socket systemd-udevd-kernel.socket systemd-udevd.service >/dev/null 2>&1 || :
 
@@ -476,7 +478,6 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %{_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
 %{_datadir}/dbus-1/system.d/org.freedesktop.hostname1.conf
 %{_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
-%{_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
 %{_sysconfdir}/pam.d/systemd-user
 %ghost %{_sysconfdir}/udev/hwdb.bin
 %{_rpmconfigdir}/macros.d/macros.systemd
@@ -513,7 +514,6 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %{_bindir}/systemd-inhibit
 %{_bindir}/systemd-path
 %{_bindir}/systemd-hwdb
-%{_bindir}/systemd-resolve
 %{_bindir}/hostnamectl
 %{_prefix}/lib/tmpfiles.d/systemd.conf
 %{_prefix}/lib/tmpfiles.d/systemd-nologin.conf
@@ -544,17 +544,22 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %{_datadir}/dbus-1/*/org.freedesktop.systemd1.service
 %{_datadir}/dbus-1/system-services/org.freedesktop.hostname1.service
 %{_datadir}/dbus-1/system-services/org.freedesktop.login1.service
-%{_datadir}/dbus-1/system-services/org.freedesktop.resolve1.service
 %{_datadir}/polkit-1/actions/org.freedesktop.systemd1.policy
 %{_datadir}/polkit-1/actions/org.freedesktop.hostname1.policy
 %{_datadir}/polkit-1/actions/org.freedesktop.login1.policy
-%{_datadir}/polkit-1/actions/org.freedesktop.resolve1.policy
 %{_datadir}/bash-completion/completions/*
 # These 2 files should land in /usr/lib without depending on 32/64 bits.
 %{_prefix}/lib/environment.d/99-environment.conf
 %{_prefix}/lib/modprobe.d/systemd.conf
 %license LICENSE.GPL2
 %license LICENSE.LGPL2.1
+
+%if %{without systemd_bootstrap}
+%{_bindir}/systemd-resolve
+%{_datadir}/dbus-1/system-services/org.freedesktop.resolve1.service
+%{_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
+%{_datadir}/polkit-1/actions/org.freedesktop.resolve1.policy
+%endif
 
 # Just make sure we don't package these by default
 %exclude %{_prefix}/lib/systemd/system/default.target
@@ -569,12 +574,14 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %defattr(-,root,root,-)
 %{_sysconfdir}/systemd/journald.conf
 %{_sysconfdir}/systemd/logind.conf
-%{_sysconfdir}/systemd/resolved.conf
 %{_sysconfdir}/systemd/system.conf
 %{_sysconfdir}/systemd/user.conf
 %{_sysconfdir}/udev/udev.conf
 %{system_unit_dir}/default.target
 %{system_unit_dir}/user@.service
+%if %{without systemd_bootstrap}
+%{_sysconfdir}/systemd/resolved.conf
+%endif
 
 %if %{without systemd_bootstrap}
 %files doc
@@ -597,8 +604,10 @@ for a in `find /etc/systemd/system -type l ! -exec test -e {} \; -print`; do sta
 %{_libdir}/libudev.so.*
 %{_libdir}/libsystemd.so.*
 %{_libdir}/libnss_systemd.so.*
+%if %{without systemd_bootstrap}
 %{_libdir}/libnss_resolve.so.2
 %{_libdir}/libnss_myhostname.so.2
+%endif
 
 %files devel
 %dir %{_includedir}/systemd

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -254,6 +254,8 @@ CONFIGURE_OPTS=(
         -Dselinux=true
         -Dresolve=true
         -Dmyhostname=true
+        # Disable DNSSEC by default, until systemd update. JB#63704
+        -Ddefault-dnssec=no
 %else
         -Dtests=false
         -Dinstall-tests=false


### PR DESCRIPTION
The DNSSEC may cause issues in some environments and in those cases for normal user it's not clear why things are not working. So it's better do disable it by default. This is seems to be the default also on Fedora and OpenSUSE.

Also synced the systemd-mini.spec as it had gotten out of sync. Added packaging guide README and moved the precheckin.sh script to top level to make it more clear how things should be done in the future.